### PR TITLE
Export all functions from graphitesend, not only from graphitesend.graphitesend

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-graphitesend (0.0.4-1) UNRELEASED; urgency=low
+graphitesend (0.4.0-1) UNRELEASED; urgency=low
 
   * Initial release. (Closes: #XXXXXX)
 

--- a/graphitesend/__init__.py
+++ b/graphitesend/__init__.py
@@ -1,1 +1,1 @@
-from graphitesend import *
+from graphitesend import * # noqa

--- a/graphitesend/__init__.py
+++ b/graphitesend/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.4.0"
+from graphitesend import *

--- a/graphitesend/graphitesend.py
+++ b/graphitesend/graphitesend.py
@@ -14,6 +14,7 @@ default_graphite_plaintext_port = 2003
 default_graphite_server = 'graphite'
 log = logging.getLogger(__name__)
 
+__version__ = "0.4.0"
 
 class GraphiteSendException(Exception):
     pass

--- a/graphitesend/graphitesend.py
+++ b/graphitesend/graphitesend.py
@@ -15,6 +15,7 @@ log = logging.getLogger(__name__)
 
 __version__ = "0.4.0"
 
+
 class GraphiteSendException(Exception):
     pass
 

--- a/graphitesend/graphitesend.py
+++ b/graphitesend/graphitesend.py
@@ -6,7 +6,6 @@ import pickle
 import socket
 import struct
 import time
-from __init__ import __version__  # noqa
 _module_instance = None
 
 default_graphite_pickle_port = 2004


### PR DESCRIPTION
What this does is it exports everything from graphitesend.graphitesend to graphitesend, so you can do e.g. from graphitesend import init

Makes the documentation examples work:
```python
>>> import graphitesend
>>> graphitesend.init()
```

Fixes #21 

I've also gone ahead and fixed the version in debian/changelog while I was on it.