### PR TITLE
Add autoreconnect feature

### DIFF
--- a/graphitesend/graphitesend.py
+++ b/graphitesend/graphitesend.py
@@ -182,6 +182,27 @@ class GraphiteClient(object):
         self.disconnect()
         self.connect()
 
+    def autoreconnect(self, sleep=1, attempt=3):
+        """
+        Tries to reconnect up to `attempt` times with `sleep` seconds between
+        each try
+
+        :param sleep: time to sleep between two attempts to reconnect
+        :type prefix: float or int
+        :param attempt: maximal number of attempts
+        :type attempt: int
+        """
+
+        while attempt is None or attempt > 0:
+            try:
+                self.reconnect()
+                return True
+            except GraphiteSendException:
+                time.sleep(sleep)
+                attempt -= 1
+
+        return False
+
     def clean_metric_name(self, metric_name):
         """
         Make sure the metric is free of control chars, spaces, tabs, etc.

--- a/graphitesend/graphitesend.py
+++ b/graphitesend/graphitesend.py
@@ -243,15 +243,15 @@ class GraphiteClient(object):
                 "Socket was not created before send"
             )
 
-        fct = self._send
+        sending_function = self._send
         if self._autoreconnect:
-            fct = self._send_and_reconnect
+            sending_function = self._send_and_reconnect
 
         try:
             if self.asynchronous and gevent:
-                gevent.spawn(fct, message.encode("ascii"))
+                gevent.spawn(sending_function, message.encode("ascii"))
             else:
-                fct(message.encode("ascii"))
+                sending_function(message.encode("ascii"))
         except Exception as e:
             self._handle_send_error(e)
 

--- a/graphitesend/graphitesend.py
+++ b/graphitesend/graphitesend.py
@@ -431,7 +431,6 @@ class GraphiteClient(object):
         return self._dispatch_send(message)
 
 
-
 class GraphitePickleClient(GraphiteClient):
 
     def __init__(self, *args, **kwargs):

--- a/tests/test_autoreconnect.py
+++ b/tests/test_autoreconnect.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+
+from graphitesend import graphitesend
+import unittest
+import socket
+
+
+class TestAutoreconnect(unittest.TestCase):
+
+    def setUp(self):
+        """ reset graphitesend """
+        self.server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.server.bind(('localhost', 2003))
+        self.server.listen(5)
+
+    def tearDown(self):
+        """ reset graphitesend """
+        # Drop any connections or modules that have been setup from other tests
+        graphitesend.reset()
+        try:
+            self.server.shutdown(socket.SHUT_RD)
+            self.server.close()
+        except Exception:
+            pass
+        self.server = None
+
+    def test_set_autoreconnect_default(self):
+        g = graphitesend.init(dryrun=True)
+        self.assertEqual(g._autoreconnect, False)
+
+    def test_set_autoreconnect_true(self):
+        g = graphitesend.init(dryrun=True, autoreconnect=True)
+        self.assertEqual(g._autoreconnect, True)
+
+    def test_set_autoreconnect_false(self):
+        g = graphitesend.init(dryrun=True, autoreconnect=False)
+        self.assertEqual(g._autoreconnect, False)
+
+    def test_autoreconnect(self):
+        g = graphitesend.GraphiteClient(autoreconnect=True)
+        g.send("metric", 42)
+        self.tearDown()
+        with self.assertRaises(graphitesend.GraphiteSendException):
+            g.send("metric", 2)
+        self.setUp()
+        g.send("metric", 3)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -132,14 +132,14 @@ class TestCli(unittest.TestCase):
     def test_dryrun(self):
         g = graphitesend.init(dryrun=True)
         dryrun_messsage_send = 'testing dryrun'
-        dryrun_messsage_recv = g._send(dryrun_messsage_send)
+        dryrun_messsage_recv = g._dispatch_send(dryrun_messsage_send)
         self.assertEqual(dryrun_messsage_recv, dryrun_messsage_send)
 
     def test_send_gaierror(self):
         g = graphitesend.init()
         g.socket = True
         with self.assertRaises(graphitesend.GraphiteSendException):
-            g._send('test')
+            g._dispatch_send('test')
 
     def test_str2listtuple_bad(self):
         g = graphitesend.init(init_type='pickle')


### PR DESCRIPTION
Hi,

I've implemented a new option to the `GraphiteClient` object. It will try to reconnect automatically to the server when `autoreconnect` is set to `True`. Of course the default is `False`.

By default, it will try to reconnect 3 times with 1 second of interval. If you have opinion on these default, let me know as I'm not sure if these are the best. After these tries, an error will be thrown like before if `GraphiteClient` didn't reconnect successfully.

I splited the `_send` function to allow more modularity, I hope you don't mind.

Finally, I added tests for this function, based on what you've done for async feature.

I hope you like the idea, but feel free to tell me what dislike you.