### PR TITLE
fix: Try send message again when socket empty

### DIFF
--- a/graphitesend/graphitesend.py
+++ b/graphitesend/graphitesend.py
@@ -292,12 +292,21 @@ class GraphiteClient(object):
         self.socket.sendall(message.encode("ascii"))
 
     def _send_and_reconnect(self, message):
+        """Send _message_ to Graphite Server and attempt reconnect on failure.
 
+        If _autoreconnect_ was specified, attempt to reconnect if first send
+        fails.
+
+        :raises AttributeError: When the socket has not been set.
+        :raises socket.error: When the socket connection is no longer valid.
+        """
         try:
             self.socket.sendall(message.encode("ascii"))
-        except socket.error:
+        except (AttributeError, socket.error):
             if not self.autoreconnect():
                 raise
+            else:
+                self.socket.sendall(message.encode("ascii"))
 
     def _presend(self, message):
         """


### PR DESCRIPTION
Seems like the expected behaviour of _send_and_reconnect() would be to
reconnect to Graphite if the first sendall() fails. If we get to this
spot without initializing the socket, we should attempt to connect then
try again.