### PR TITLE
Added python2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: python
 
 python:
+  - "2.6"
   - "2.7"
+ 
 # command to install dependencies
 install:
-  - "pip install -r requirements.txt"
+  - "pip install -r requirements-test.txt"
   - "pip install gevent"
 
 # command to run tests

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+0.7.0
+-----
+	* Added python2.6 support, minor formatting change + unitest2
+
 0.6.1
 -----
 	* Added optional clean_metric_name (@Shir0kamii)

--- a/graphitesend/graphitesend.py
+++ b/graphitesend/graphitesend.py
@@ -20,7 +20,7 @@ default_graphite_plaintext_port = 2003
 default_graphite_server = 'graphite'
 log = logging.getLogger(__name__)
 
-VERSION = "0.6.1"
+VERSION = "0.7.0"
 
 
 class GraphiteSendException(Exception):
@@ -261,8 +261,7 @@ class GraphiteClient(object):
         except Exception as e:
             self._handle_send_error(e)
 
-        return "sent {:d} long message: {:.75}".format(
-            len(message), message)
+        return "sent {0} long message: {1}".format(len(message), message[:75])
 
     def _handle_send_error(self, error):
         if isinstance(error, socket.gaierror):

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,7 @@
+-r requirements.txt
+coverage
+nose
+pep8
+tox
+coveralls
+unittest2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,1 @@
 argparse
-coverage
-nose
-pep8
-tox
-coveralls

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 
 setup(
     name='graphitesend',
-    version='0.6.1',
+    version='0.7.0',
     description='A simple interface for sending metrics to Graphite',
     author='Danny Lawrence',
     author_email='dannyla@linux.com',

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from graphitesend import graphitesend
-import unittest
+import unittest2 as unittest
 import socket
 import os
 

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from graphitesend import graphitesend
-import unittest
+import unittest2 as unittest
 import socket
 
 

--- a/tests/test_autoreconnect.py
+++ b/tests/test_autoreconnect.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from graphitesend import graphitesend
-import unittest
+import unittest2 as unittest
 import socket
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,4 @@
-import unittest
+import unittest2 as unittest
 from graphitesend import graphitesend
 import os
 import socket

--- a/tests/test_housekeeping.py
+++ b/tests/test_housekeeping.py
@@ -1,4 +1,4 @@
-import unittest
+import unittest2 as unittest
 import os
 import datetime
 


### PR DESCRIPTION
- Minor formatting fix for python2.6
- Move `unittests` to `unitest2` (py27 port of unittest into py26)
- upped version to 0.7.0
- fixes issue https://github.com/daniellawrence/graphitesend/issues/47