### PR TITLE
fix: Init can use relative imports

### DIFF
--- a/graphitesend/__init__.py
+++ b/graphitesend/__init__.py
@@ -1,1 +1,1 @@
-from graphitesend import *  # noqa
+from .graphitesend import *  # noqa


### PR DESCRIPTION
Using a relative import solves a discrepancy between Python 2.7.11 and
3.5.1. For some reason, 2.7.11 brings all the module objects down to the
expected `graphitesend.*` level using an absolute import, while 3.5.1
leaves the objects at the `graphitesend.graphitesend.*` level. The
relative import will bring everything down to `graphitesend.*` for
2.7.11 and 3.5.1.