### PR TITLE
fix: Change asynchronous dependencies for tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,11 +10,13 @@ deps = flake8
 commands = flake8 --exclude=.tox,.virtualenv --ignore=E501
 
 [testenv:nosetests]
-deps = -rrequirements-asynchronous.txt
+deps =
+    gevent
+    -rrequirements-test.txt
 commands = nosetests --with-coverage --cover-package=graphitesend
 
 [testenv:90%coverage]
-deps = -rrequirements-asynchronous.txt
+deps =
+    gevent
+    -rrequirements-test.txt
 commands = coverage report --fail-under=90
-
-


### PR DESCRIPTION
Noticed WARNINGS in Travis CI output:

WARNING:test command found but not installed in testenv

Looks like the test environments expected to use `requirements-test.txt`
with one extra package, `gevent`. Tests should be able to run without
issues.