### PR TITLE
Fixing issue for Python3 (bytes object has no method encode)

### DIFF
--- a/graphitesend/graphitesend.py
+++ b/graphitesend/graphitesend.py
@@ -255,9 +255,9 @@ class GraphiteClient(object):
 
         try:
             if self.asynchronous and gevent:
-                gevent.spawn(sending_function, message.encode("ascii"))
+                gevent.spawn(sending_function, message)
             else:
-                sending_function(message.encode("ascii"))
+                sending_function(message)
         except Exception as e:
             self._handle_send_error(e)
 


### PR DESCRIPTION
Dispatch method uses methods that attempts to encode a bytes object when it had already.

The fix is to not encode the message in the dispatch method as the actual send methods will encode the message.