### PR TITLE
Add exponential backoff logic for autoreconnect

### DIFF
--- a/graphitesend/graphitesend.py
+++ b/graphitesend/graphitesend.py
@@ -11,6 +11,8 @@ import pickle
 import socket
 import struct
 import time
+import random
+
 _module_instance = None
 
 default_graphite_pickle_port = 2004
@@ -187,23 +189,42 @@ class GraphiteClient(object):
         self.disconnect()
         self.connect()
 
-    def autoreconnect(self, sleep=1, attempt=3):
+    def autoreconnect(self, sleep=1, attempt=3, exponential=True, jitter=5):
         """
-        Tries to reconnect up to `attempt` times with `sleep` seconds between
+        Tries to reconnect with some delay:
+
+        exponential=False: up to `attempt` times with `sleep` seconds between
         each try
 
+        exponential=True: up to `attempt` times with exponential growing `sleep`
+        and random delay in range 1..`jitter` (exponential backoff)
+
+
         :param sleep: time to sleep between two attempts to reconnect
-        :type prefix: float or int
+        :type sleep: float or int
         :param attempt: maximal number of attempts
         :type attempt: int
+        :param exponential: if set - use exponential backoff logic
+        :type exponential: bool
+        :param jitter: top value of random delay, sec
+        :type jitter: int
+
         """
+
+        p = 0
 
         while attempt is None or attempt > 0:
             try:
                 self.reconnect()
                 return True
             except GraphiteSendException:
-                time.sleep(sleep)
+
+                if exponential:
+                    p += 1
+                    time.sleep(pow(sleep, p) + random.randint(1, jitter))
+                else:
+                    time.sleep(sleep)
+
                 attempt -= 1
 
         return False


### PR DESCRIPTION
It might be useful to add ability exponential backoff for autoreconnect method.

"The idea behind exponential backoff is to use progressively longer waits between retries for consecutive error responses. You should implement a maximum delay interval, as well as a maximum number of retries. .. Most exponential backoff algorithms use jitter (randomized delay) to prevent successive collisions"  ( http://docs.aws.amazon.com/general/latest/gr/api-retries.html )
