### PR TITLE
lock flake8 - due to python2.6 support

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,4 +5,6 @@ pep8
 tox
 coveralls
 unittest2
-flake8
+
+# py26...
+flake8==2.6.2


### PR DESCRIPTION
Flake8 has dropped support for python2.6 in the 3.0.0 release.
We need to lock our version of flake8 to 2.6.2 in order to work around this for now