### PR TITLE
Python 3 support fix on _send method

### DIFF
--- a/graphitesend/graphitesend.py
+++ b/graphitesend/graphitesend.py
@@ -381,6 +381,9 @@ class GraphiteClient(object):
         """
         Given a message send it to the graphite server.
         """
+        # Python 3 support
+        if type(message) == bytes:
+            message = str(message, 'utf-8')
 
         self.socket.sendall(message.encode("ascii"))
 


### PR DESCRIPTION
Running a `Django v1.10` app with `Python v3.4.3`, the _send method breaks.
Stack trace:
```
  File "/home/pablo/.virtualenvs/test/local/lib/python3.4/site-packages/graphitesend/graphitesend.py", line 291, in _send
    self.socket.sendall(message.encode("ascii"))
AttributeError: 'bytes' object has no attribute 'encode'

...
graphitesend.graphitesend.GraphiteSendException: Unknown error while trying to send data down socket to ('172.17.0.2', 8000), error: 'bytes' object has no attribute 'encode'
```