### PR TITLE
Use setuptools instead of distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='graphitesend',


### PR DESCRIPTION
While maintaining rpm package for Fedora/EPEL, I spotted the problem described below.

`setuptools` provides support for options `entry_points` and
`extras_requires`, which are used in setup.py.

This commit fix errors like below during installation:
```
/usr/lib64/python2.7/distutils/dist.py:267: UserWarning: Unknown distribution option: 'entry_points'
  warnings.warn(msg)
/usr/lib64/python2.7/distutils/dist.py:267: UserWarning: Unknown distribution option: 'extras_require'
  warnings.warn(msg)
```